### PR TITLE
BYTE-123: 24 Hour Countdown

### DIFF
--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -11,23 +11,45 @@
         timerType: '{{ $timerType }}',
         endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
-
             if( this.timerType === '24'){
               let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-                let [hours, minutes, seconds] = this.endsAtTime.split(':');
-                let now = new Date();
-                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
-                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
                 let timeDistance = countDownDate - new Date().getTime();
+
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;
                 }
+
+                const [hours, minutes, seconds] = this.endsAtTime.split(':');
+                const now = new Date();
+                const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+
+                if(now > endTime){
+                    endTime.setDate(endTime.getDate() + 1);
+                }
+
+                const currentTime = new Date();
+                let tomorrowEndTimeDistance = endTime.getTime() - currentTime.getTime();
+
+                if(tomorrowEndTimeDistance <= 0){
+                    runningCounter = setInterval(resetCounter,1000);
+                }
+
                 this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
                 this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+
+                function resetCounter() {
+                    const now = new Date();
+                    const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+                    let tomorrowEndTimeDistance = endTime.getTime() - now.getTime();
+                    if (tomorrowEndTimeDistance <= 0) {
+                      clearInterval(runningCounter);
+                      runningCounter = setInterval(resetCounter, 1000);
+                    }
+                }
             }, 1000);
         }else{
             let runningCounter = setInterval(() => {

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -13,37 +13,23 @@
         startCounter: function () {
 
             if( this.timerType === '24'){
-
               let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-
                 let [hours, minutes, seconds] = this.endsAtTime.split(':');
-
-
                 let now = new Date();
-
                 let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
-
-
                 let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
-
-
                 let timeDistance = countDownDate - new Date().getTime();
-
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;
                 }
-
-
                 this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
                 this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
             }, 1000);
-
         }else{
-
             let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
@@ -56,9 +42,7 @@
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
             }, 1000);
-
         }
-
         },
         formatCounter: function (number) {
             return number.toString().padStart(2, '0');

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -8,7 +8,42 @@
             minutes: '{{ $minutes() }}',
             seconds: '{{ $seconds() }}',
         },
+        timerType: '{{ $timerType }}',
+        endTime: '{{ $endsAtTime }}',
         startCounter: function () {
+
+            if( this.timerType === '24'){
+
+              let runningCounter = setInterval(() => {
+                let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
+
+                let [hours, minutes, seconds] = this.endTime.split(':');
+
+
+                let now = new Date();
+
+                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
+
+
+                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
+
+
+                let timeDistance = countDownDate - new Date().getTime();
+
+                if (timeDistance < 0 ) {
+                    clearInterval(runningCounter);
+                    return;
+                }
+
+
+                this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
+                this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+                this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
+                this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+            }, 1000);
+
+        }else{
+
             let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
@@ -21,6 +56,9 @@
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
             }, 1000);
+
+        }
+
         },
         formatCounter: function (number) {
             return number.toString().padStart(2, '0');

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -9,7 +9,7 @@
             seconds: '{{ $seconds() }}',
         },
         timerType: '{{ $timerType }}',
-        endTime: '{{ $endsAtTime }}',
+        endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
 
             if( this.timerType === '24'){
@@ -17,7 +17,7 @@
               let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
 
-                let [hours, minutes, seconds] = this.endTime.split(':');
+                let [hours, minutes, seconds] = this.endsAtTime.split(':');
 
 
                 let now = new Date();

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -55,7 +55,7 @@
         x-cloak
         x-show="payload.countdown_timer_enabled === true"
         wire:model="payload.countdown_timer_type"
-        wire:key="payload.countdown_timer_type"
+        wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
         label="Countdown Timer Type"
     >

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -51,6 +51,18 @@
             :toggled="$payload['countdown_timer_enabled'] ?? false"
         />
 
+    <x-fab::forms.select
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+        wire:model="payload.countdown_timer_type"
+        wire:key="payload.countdown_timer_type"
+        name="payload[countdown_timer_type]"
+        label="Countdown Timer Type"
+    >
+        <option value="24">24 Hours Countdown</option>
+        <option value="regular">Regular Countdown</option>
+    </x-fab::forms.select>
+
         <div
             class="grid grid-cols-2 w-full fab-space-x-4"
             x-cloak

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -51,46 +51,46 @@
             :toggled="$payload['countdown_timer_enabled'] ?? false"
         />
 
-    <x-fab::forms.select
-        x-cloak
-        x-show="payload.countdown_timer_enabled === true"
-        wire:model="payload.countdown_timer_type"
-        wire:key="promobar_countdown_timer_type"
-        name="payload[countdown_timer_type]"
-        label="Countdown Timer Type"
-    >
-        <option value="24">24 Hours Countdown</option>
-        <option value="regular">Regular Countdown</option>
-    </x-fab::forms.select>
-
-        <div
-            class="grid grid-cols-2 w-full fab-space-x-4"
+        <x-fab::forms.select
             x-cloak
             x-show="payload.countdown_timer_enabled === true"
+            wire:model="payload.countdown_timer_type"
+            wire:key="promobar_countdown_timer_type"
+            name="payload[countdown_timer_type]"
+            label="Countdown Timer Type"
         >
-            <x-fab::forms.date-picker
-                label="Count down until"
-                wire:model="payload.countdown_timer_end_date"
-                wire:key="promobar_countdown_timer_end_date"
-                hint="Required"
-                :options="[
-                    'altInput' => true,
-                    'altFormat' => 'D, M J, Y - G:i K',
-                    'enableTime' => true
-                ]"
-            />
+            <option value="regular">Regular Countdown</option>
+            <option value="24">24 Hours Countdown</option>
+        </x-fab::forms.select>
 
-            <x-fab::forms.date-picker
-                label="Show timer after"
-                wire:model="payload.countdown_timer_start_date"
-                wire:key="promobar_countdown_timer_start_date"
-                hint="Optional"
-                :options="[
-                    'altInput' => true,
-                    'altFormat' => 'D, M J, Y - G:i K',
-                    'enableTime' => true
-                ]"
-            />
+    <div
+        class="grid grid-cols-2 w-full fab-space-x-4"
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+    >
+        <x-fab::forms.date-picker
+            label="Count down until"
+            wire:model="payload.countdown_timer_end_date"
+            wire:key="promobar_countdown_timer_end_date"
+            hint="Required"
+            :options="[
+                'altInput' => true,
+                'altFormat' => 'D, M J, Y - G:i K',
+                'enableTime' => true
+            ]"
+        />
+
+        <x-fab::forms.date-picker
+            label="Show timer after"
+            wire:model="payload.countdown_timer_start_date"
+            wire:key="promobar_countdown_timer_start_date"
+            hint="Optional"
+            :options="[
+                'altInput' => true,
+                'altFormat' => 'D, M J, Y - G:i K',
+                'enableTime' => true
+            ]"
+        />
 
         </div>
     </div>

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -15,7 +15,7 @@
 
 @isset($payload['content'])
     <div
-        class="astrogoat_promobar mt-4 flex flex-col lg:flex-row lg:mt-0"
+        class="astrogoat_promobar mt-2 flex flex-col lg:flex-row lg:mt-0"
     >
         <span>{!! $payload['content'] ?? '' !!}</span>
 

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -15,7 +15,7 @@
 
 @isset($payload['content'])
     <div
-        class="astrogoat_promobar"
+        class="astrogoat_promobar mt-4 flex flex-col lg:flex-row lg:mt-0"
     >
         <span>{!! $payload['content'] ?? '' !!}</span>
 

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public $timerType;
-    public $endsAtTime;
+    public string $timerType;
+    public string $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -23,9 +23,9 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
-        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
+        $this->timerType = $this->payload['countdown_timer_type'] ?? "";
 
-        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
+        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public string $timerType;
-    public string $endsAtTime;
+    public $timerType;
+    public $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -23,9 +23,9 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
-        $this->timerType = $this->payload['countdown_timer_type'];
+        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
 
-        $this->endsAtTime = Carbon::parse($this->payload['countdown_timer_end_date'])->format('H:i:s');
+        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -25,7 +25,7 @@ class Countdown extends Component
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
         $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
 
-        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -25,7 +25,7 @@ class Countdown extends Component
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
         $this->timerType = $this->payload['countdown_timer_type'] ?? "";
 
-        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,6 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
+    public string $timerType;
+    public string $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -21,6 +23,9 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
+        $this->timerType = $this->payload['countdown_timer_type'];
+
+        $this->endsAtTime = Carbon::parse($this->payload['countdown_timer_end_date'])->format('H:i:s');
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public string $timerType;
-    public string $endsAtTime;
+    public ?string $timerType;
+    public ?string $endsAtTime;
 
     public function __construct(protected array $payload)
     {


### PR DESCRIPTION
**Link to ticket**: https://linear.app/3zbrands/issue/BYTE-123/24-hour-countdown

<details>
<summary>Ticket description</summary>
User Story: 

As a Strata admin user, I want to be able to choose between a 24 hr timer that resets every 24 hours until a particular end date or a regular countdown timer that counts down to a day in the future and displays days, hours, minutes, and seconds remaining.

This should be applied to the Inline and the Zaius promobar.
</details>

