### PR TITLE
BYTE-158: Styling Promobar Countdown Timer

### DIFF
--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -11,23 +11,45 @@
         timerType: '{{ $timerType }}',
         endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
-
             if( this.timerType === '24'){
               let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-                let [hours, minutes, seconds] = this.endsAtTime.split(':');
-                let now = new Date();
-                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
-                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
                 let timeDistance = countDownDate - new Date().getTime();
+
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;
                 }
+
+                const [hours, minutes, seconds] = this.endsAtTime.split(':');
+                const now = new Date();
+                const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+
+                if(now > endTime){
+                    endTime.setDate(endTime.getDate() + 1);
+                }
+
+                const currentTime = new Date();
+                let tomorrowEndTimeDistance = endTime.getTime() - currentTime.getTime();
+
+                if(tomorrowEndTimeDistance <= 0){
+                    runningCounter = setInterval(resetCounter,1000);
+                }
+
                 this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
                 this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+
+                function resetCounter() {
+                    const now = new Date();
+                    const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
+                    let tomorrowEndTimeDistance = endTime.getTime() - now.getTime();
+                    if (tomorrowEndTimeDistance <= 0) {
+                      clearInterval(runningCounter);
+                      runningCounter = setInterval(resetCounter, 1000);
+                    }
+                }
             }, 1000);
         }else{
             let runningCounter = setInterval(() => {

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -74,7 +74,6 @@
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
 
                 daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
-
                 daysBlockTwo.textContent = String(this.timer.days % 10);
                 hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
                 hoursBlockTwo.textContent = String(this.timer.hours % 10);
@@ -106,7 +105,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold">Days</span>
+                <span class="text-xs font-bold block-info">Days</span>
             </div>
 
             <div class="flex flex-col">
@@ -114,7 +113,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold">Hours</span>
+                <span class="text-xs font-bold block-info">Hours</span>
             </div>
 
             <div class="flex flex-col">
@@ -122,7 +121,7 @@
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
                     </div>
-                    <span class="text-xs font-bold">Mins</span>
+                    <span class="text-xs font-bold block-info">Mins</span>
             </div>
 
             <div class="flex flex-col">
@@ -130,7 +129,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
                 </div>
-                <span class="text-xs font-bold">Secs</span>
+                <span class="text-xs font-bold block-info">Secs</span>
             </div>
             @else
                 {{ $slot }}

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -106,7 +106,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
                 </div>
-                <span class="text-xs">Days</span>
+                <span class="text-xs font-bold">Days</span>
             </div>
 
             <div class="flex flex-col">
@@ -114,7 +114,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
                 </div>
-                <span class="text-xs">Hours</span>
+                <span class="text-xs font-bold">Hours</span>
             </div>
 
             <div class="flex flex-col">
@@ -122,7 +122,7 @@
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
                         <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
                     </div>
-                    <span class="text-xs">Mins</span>
+                    <span class="text-xs font-bold">Mins</span>
             </div>
 
             <div class="flex flex-col">
@@ -130,7 +130,7 @@
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
                 </div>
-                <span class="text-xs">Secs</span>
+                <span class="text-xs font-bold">Secs</span>
             </div>
             @else
                 {{ $slot }}

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -101,7 +101,7 @@
         <div class="flex gap-2 justify-center mt-4 md:mt-0 timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
 
-            <div class="flex flex-col">
+            <div class="flex flex-col" x-show="timerType === 'regular'">
                 <div class="flex days-block gap-1 font-bold">
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
                     <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -98,37 +98,37 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <div class="flex gap-2 justify-center mt-4 md:mt-0" x-show="timerIsRunning">
+        <div class="flex gap-2 justify-center mt-4 md:mt-0 timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
 
             <div class="flex flex-col">
-                <div class="flex days-block gap-2 font-bold">
-                    <span class="countdown-block px-2 rounded" id="daysBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded" id="daysBlockTwo">-</span>
+                <div class="flex days-block gap-1 font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
                 </div>
                 <span class="text-xs">Days</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex months-block gap-2 font-bold">
-                    <span class="countdown-block px-2 rounded" id="hoursBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded" id="hoursBlockTwo">-</span>
+                <div class="flex months-block gap-1 font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
                 </div>
                 <span class="text-xs">Hours</span>
             </div>
 
             <div class="flex flex-col">
-                    <div class="flex minutes-block gap-2  font-bold">
-                        <span class="countdown-block px-2 rounded" id="minutesBlockOne">-</span>
-                        <span class="countdown-block px-2 rounded" id="minutesBlockTwo">-</span>
+                    <div class="flex minutes-block gap-1  font-bold">
+                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
+                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
                     </div>
                     <span class="text-xs">Mins</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex seconds-block gap-2 rounded font-bold">
-                    <span class="countdown-block px-2 rounded" id="secondsBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded" id="secondsBlockTwo">-</span>
+                <div class="flex seconds-block gap-1 rounded-sm font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
                 </div>
                 <span class="text-xs">Secs</span>
             </div>

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -1,5 +1,5 @@
 @if($timerIsRunning())
-    <span
+    <div
         x-data="
     {
         timer: {
@@ -41,6 +41,15 @@
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
 
+                daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
+                daysBlockTwo.textContent = String(this.timer.days % 10);
+                hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
+                hoursBlockTwo.textContent = String(this.timer.hours % 10);
+                minutesBlockOne.textContent = String(Math.floor(this.timer.minutes / 10));
+                minutesBlockTwo.textContent = String(this.timer.minutes % 10);
+                secondsBlockOne.textContent = String(Math.floor(this.timer.seconds / 10));
+                secondsBlockTwo.textContent = String(this.timer.seconds % 10);
+
                 function resetCounter() {
                     const now = new Date();
                     const endTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hours, minutes, seconds);
@@ -63,6 +72,18 @@
                 this.timer.hours = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
+
+                daysBlockOne.textContent = String(Math.floor(this.timer.days / 10));
+
+                daysBlockTwo.textContent = String(this.timer.days % 10);
+                hoursBlockOne.textContent = String(Math.floor(this.timer.hours / 10));
+                hoursBlockTwo.textContent = String(this.timer.hours % 10);
+                minutesBlockOne.textContent = String(Math.floor(this.timer.minutes / 10));
+                minutesBlockTwo.textContent = String(this.timer.minutes % 10);
+                secondsBlockOne.textContent = String(Math.floor(this.timer.seconds / 10));
+                secondsBlockTwo.textContent = String(this.timer.seconds % 10);
+
+
             }, 1000);
         }
         },
@@ -77,38 +98,43 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <span class="flex gap-2" x-show="timerIsRunning">
+        <div class="flex gap-2 justify-center mt-4 md:mt-0" x-show="timerIsRunning">
             @if ($slot->isEmpty())
-                <div class="flex flex-col w-12">
-                     <span
-                        class="days-block p-1 rounded font-bold"
-                        x-text="timer.days">{{ $days() }}</span>
-                    <span class="text-xs">Days</span>
-                </div>
 
-                <div class="flex flex-col w-12">
-                    <span
-                        class="months-block p-1 rounded font-bold"
-                        x-text="timer.hours">{{ $hours() }}</span>
-                    <span class="text-xs">Hours</span>
+            <div class="flex flex-col">
+                <div class="flex days-block gap-2 font-bold">
+                    <span class="countdown-block px-2 rounded" id="daysBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded" id="daysBlockTwo">-</span>
                 </div>
+                <span class="text-xs">Days</span>
+            </div>
 
-                <div class="flex flex-col w-12">
-                    <span
-                        class="minutes-block p-1 rounded font-bold"
-                        x-text="timer.minutes">{{ $minutes() }}</span>
-                     <span class="text-xs">Mins</span>
+            <div class="flex flex-col">
+                <div class="flex months-block gap-2 font-bold">
+                    <span class="countdown-block px-2 rounded" id="hoursBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded" id="hoursBlockTwo">-</span>
                 </div>
+                <span class="text-xs">Hours</span>
+            </div>
 
-                <div class="flex flex-col w-12">
-                    <span
-                        class=" seconds-block p-1 rounded font-bold"
-                        x-text="timer.seconds">{{ $seconds() }}</span>
-                    <span class="text-xs">Secs</span>
+            <div class="flex flex-col">
+                    <div class="flex minutes-block gap-2  font-bold">
+                        <span class="countdown-block px-2 rounded" id="minutesBlockOne">-</span>
+                        <span class="countdown-block px-2 rounded" id="minutesBlockTwo">-</span>
+                    </div>
+                    <span class="text-xs">Mins</span>
+            </div>
+
+            <div class="flex flex-col">
+                <div class="flex seconds-block gap-2 rounded font-bold">
+                    <span class="countdown-block px-2 rounded" id="secondsBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded" id="secondsBlockTwo">-</span>
                 </div>
+                <span class="text-xs">Secs</span>
+            </div>
             @else
                 {{ $slot }}
             @endif
-        </span>
-    </span>
+        </div>
+    </div>
 @endif

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -98,7 +98,7 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <div class="flex gap-2 justify-center mt-4 md:mt-0 timer-container" x-show="timerIsRunning">
+        <div class="flex gap-2 justify-center mt-2 md:mt-0 timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
 
             <div class="flex flex-col" x-show="timerType === 'regular'">

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -97,37 +97,37 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <div class="flex gap-2 justify-center mt-2 md:mt-0 timer-container" x-show="timerIsRunning">
+        <div class="flex justify-center timer-container" x-show="timerIsRunning">
             @if ($slot->isEmpty())
 
             <div class="flex flex-col" x-show="timerType === 'regular'">
-                <div class="flex days-block gap-1 font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="daysBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="daysBlockTwo">-</span>
+                <div class="flex days-block">
+                    <span class="countdown-block" id="daysBlockOne">-</span>
+                    <span class="countdown-block" id="daysBlockTwo">-</span>
                 </div>
                 <span class="text-xs font-bold block-info">Days</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex months-block gap-1 font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="hoursBlockTwo">-</span>
+                <div class="flex months-block">
+                    <span class="countdown-block" id="hoursBlockOne">-</span>
+                    <span class="countdown-block" id="hoursBlockTwo">-</span>
                 </div>
                 <span class="text-xs font-bold block-info">Hours</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex minutes-block gap-1  font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
+                <div class="flex minutes-block">
+                    <span class="countdown-block" id="minutesBlockOne">-</span>
+                    <span class="countdown-block" id="minutesBlockTwo">-</span>
                 </div>
                 <span class="text-xs font-bold block-info">Mins</span>
             </div>
 
             <div class="flex flex-col">
-                <div class="flex seconds-block gap-1 rounded-sm font-bold">
-                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockOne">-</span>
-                    <span class="countdown-block px-2 rounded-sm" id="secondsBlockTwo">-</span>
+                <div class="flex seconds-block">
+                    <span class="countdown-block" id="secondsBlockOne">-</span>
+                    <span class="countdown-block" id="secondsBlockTwo">-</span>
                 </div>
                 <span class="text-xs font-bold block-info">Secs</span>
             </div>

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -117,11 +117,11 @@
             </div>
 
             <div class="flex flex-col">
-                    <div class="flex minutes-block gap-1  font-bold">
-                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
-                        <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
-                    </div>
-                    <span class="text-xs font-bold block-info">Mins</span>
+                <div class="flex minutes-block gap-1  font-bold">
+                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockOne">-</span>
+                    <span class="countdown-block px-2 rounded-sm" id="minutesBlockTwo">-</span>
+                </div>
+                <span class="text-xs font-bold block-info">Mins</span>
             </div>
 
             <div class="flex flex-col">

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -33,12 +33,35 @@
         x-init="startCounter()"
         {{ $attributes }}
     >
-        <span x-show="timerIsRunning">
+        <span class="flex gap-2" x-show="timerIsRunning">
             @if ($slot->isEmpty())
-                <span x-text="timer.days">{{ $days() }}</span> :
-                <span x-text="timer.hours">{{ $hours() }}</span> :
-                <span x-text="timer.minutes">{{ $minutes() }}</span> :
-                <span x-text="timer.seconds">{{ $seconds() }}</span>
+                <div class="flex flex-col w-12">
+                     <span
+                        class="days-block p-1 rounded font-bold"
+                        x-text="timer.days">{{ $days() }}</span>
+                    <span class="text-xs">Days</span>
+                </div>
+
+                <div class="flex flex-col w-12">
+                    <span
+                        class="months-block p-1 rounded font-bold"
+                        x-text="timer.hours">{{ $hours() }}</span>
+                    <span class="text-xs">Hours</span>
+                </div>
+
+                <div class="flex flex-col w-12">
+                    <span
+                        class="minutes-block p-1 rounded font-bold"
+                        x-text="timer.minutes">{{ $minutes() }}</span>
+                     <span class="text-xs">Mins</span>
+                </div>
+
+                <div class="flex flex-col w-12">
+                    <span
+                        class=" seconds-block p-1 rounded font-bold"
+                        x-text="timer.seconds">{{ $seconds() }}</span>
+                    <span class="text-xs">Secs</span>
+                </div>
             @else
                 {{ $slot }}
             @endif

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -13,37 +13,23 @@
         startCounter: function () {
 
             if( this.timerType === '24'){
-
               let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
-
                 let [hours, minutes, seconds] = this.endsAtTime.split(':');
-
-
                 let now = new Date();
-
                 let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
-
-
                 let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
-
-
                 let timeDistance = countDownDate - new Date().getTime();
-
                 if (timeDistance < 0 ) {
                     clearInterval(runningCounter);
                     return;
                 }
-
-
                 this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
                 this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
                 this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
             }, 1000);
-
         }else{
-
             let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
@@ -56,9 +42,7 @@
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
             }, 1000);
-
         }
-
         },
         formatCounter: function (number) {
             return number.toString().padStart(2, '0');

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -8,7 +8,42 @@
             minutes: '{{ $minutes() }}',
             seconds: '{{ $seconds() }}',
         },
+        timerType: '{{ $timerType }}',
+        endTime: '{{ $endsAtTime }}',
         startCounter: function () {
+
+            if( this.timerType === '24'){
+
+              let runningCounter = setInterval(() => {
+                let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
+
+                let [hours, minutes, seconds] = this.endTime.split(':');
+
+
+                let now = new Date();
+
+                let tomorrowEndTime = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, hours, minutes, seconds);
+
+
+                let tomorrowEndTimeDistance = tomorrowEndTime.getTime() - now.getTime();
+
+
+                let timeDistance = countDownDate - new Date().getTime();
+
+                if (timeDistance < 0 ) {
+                    clearInterval(runningCounter);
+                    return;
+                }
+
+
+                this.timer.days = this.formatCounter(Math.floor(tomorrowEndTimeDistance / (1000 * 60 * 60 * 24)));
+                this.timer.hours = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)));
+                this.timer.minutes = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60 * 60)) / (1000 * 60)));
+                this.timer.seconds = this.formatCounter(Math.floor((tomorrowEndTimeDistance % (1000 * 60)) / 1000));
+            }, 1000);
+
+        }else{
+
             let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
                 let timeDistance = countDownDate - new Date().getTime();
@@ -21,6 +56,9 @@
                 this.timer.minutes = this.formatCounter(Math.floor((timeDistance % (1000 * 60 * 60)) / (1000 * 60)));
                 this.timer.seconds = this.formatCounter(Math.floor((timeDistance % (1000 * 60)) / 1000));
             }, 1000);
+
+        }
+
         },
         formatCounter: function (number) {
             return number.toString().padStart(2, '0');

--- a/resources/views/components/countdown.blade.php
+++ b/resources/views/components/countdown.blade.php
@@ -9,7 +9,7 @@
             seconds: '{{ $seconds() }}',
         },
         timerType: '{{ $timerType }}',
-        endTime: '{{ $endsAtTime }}',
+        endsAtTime: '{{ $endsAtTime }}',
         startCounter: function () {
 
             if( this.timerType === '24'){
@@ -17,7 +17,7 @@
               let runningCounter = setInterval(() => {
                 let countDownDate = new Date({{ $endsAt->timestamp }} * 1000).getTime();
 
-                let [hours, minutes, seconds] = this.endTime.split(':');
+                let [hours, minutes, seconds] = this.endsAtTime.split(':');
 
 
                 let now = new Date();

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -83,6 +83,24 @@
         </div>
     </div>
 
+
+    <div class="grid grid-cols-2 w-full gap-4  mt-6">
+        <x-fab::forms.input
+            label="Block Background Color"
+            type="color"
+            wire:model="payload.countdown_timer_block_background_color"
+            wire:key="promobar_countdown_timer_block_background_color"
+        />
+
+        <x-fab::forms.input
+            label="Block Color"
+            type="color"
+            wire:model="payload.countdown_timer_block_color"
+            wire:key="promobar_countdown_timer_block_color"
+        />
+
+    </div>
+
     <x-fab::layouts.panel
         title="Preview"
         class="mt-8"

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -95,15 +95,30 @@
         </div>
     </div>
 
-
-    <div class="grid grid-cols-2 w-full gap-4  mt-6">
+    <div
+        class="grid grid-cols-2 w-full gap-4 mt-4 p-2"
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+    >
         <x-fab::forms.input
             label="Block Background Color"
             type="color"
             wire:model="payload.countdown_timer_block_background_color"
             wire:key="promobar_countdown_timer_block_background_color"
         />
+
+        <x-fab::forms.range
+            label="Block L & R Padding"
+            min="0"
+            max="2"
+            name="payload['countdown_timer_block_padding']"
+            wire:model="payload.countdown_timer_block_padding"
+            wire:key="promobar_countdown_timer_block_padding"
+            placeholder="2"
+            trailing="px"
+        />
     </div>
+
 
     <x-fab::layouts.panel
         title="Preview"

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -103,14 +103,6 @@
             wire:model="payload.countdown_timer_block_background_color"
             wire:key="promobar_countdown_timer_block_background_color"
         />
-
-        <x-fab::forms.input
-            label="Block Color"
-            type="color"
-            wire:model="payload.countdown_timer_block_color"
-            wire:key="promobar_countdown_timer_block_color"
-        />
-
     </div>
 
     <x-fab::layouts.panel

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -55,7 +55,7 @@
         x-cloak
         x-show="payload.countdown_timer_enabled === true"
         wire:model="payload.countdown_timer_type"
-        wire:key="payload.countdown_timer_type"
+        wire:key="promobar_countdown_timer_type"
         name="payload[countdown_timer_type]"
         label="Countdown Timer Type"
     >

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -51,6 +51,18 @@
             :toggled="$payload['countdown_timer_enabled'] ?? false"
         />
 
+    <x-fab::forms.select
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+        wire:model="payload.countdown_timer_type"
+        wire:key="payload.countdown_timer_type"
+        name="payload[countdown_timer_type]"
+        label="Countdown Timer Type"
+    >
+        <option value="24">24 Hours Countdown</option>
+        <option value="regular">Regular Countdown</option>
+    </x-fab::forms.select>
+
         <div
             class="grid grid-cols-2 w-full fab-space-x-4"
             x-cloak

--- a/resources/views/settings/types/inline.blade.php
+++ b/resources/views/settings/types/inline.blade.php
@@ -51,46 +51,46 @@
             :toggled="$payload['countdown_timer_enabled'] ?? false"
         />
 
-    <x-fab::forms.select
-        x-cloak
-        x-show="payload.countdown_timer_enabled === true"
-        wire:model="payload.countdown_timer_type"
-        wire:key="promobar_countdown_timer_type"
-        name="payload[countdown_timer_type]"
-        label="Countdown Timer Type"
-    >
-        <option value="24">24 Hours Countdown</option>
-        <option value="regular">Regular Countdown</option>
-    </x-fab::forms.select>
-
-        <div
-            class="grid grid-cols-2 w-full fab-space-x-4"
+        <x-fab::forms.select
             x-cloak
             x-show="payload.countdown_timer_enabled === true"
+            wire:model="payload.countdown_timer_type"
+            wire:key="promobar_countdown_timer_type"
+            name="payload[countdown_timer_type]"
+            label="Countdown Timer Type"
         >
-            <x-fab::forms.date-picker
-                label="Count down until"
-                wire:model="payload.countdown_timer_end_date"
-                wire:key="promobar_countdown_timer_end_date"
-                hint="Required"
-                :options="[
-                    'altInput' => true,
-                    'altFormat' => 'D, M J, Y - G:i K',
-                    'enableTime' => true
-                ]"
-            />
+            <option value="regular">Regular Countdown</option>
+            <option value="24">24 Hours Countdown</option>
+        </x-fab::forms.select>
 
-            <x-fab::forms.date-picker
-                label="Show timer after"
-                wire:model="payload.countdown_timer_start_date"
-                wire:key="promobar_countdown_timer_start_date"
-                hint="Optional"
-                :options="[
-                    'altInput' => true,
-                    'altFormat' => 'D, M J, Y - G:i K',
-                    'enableTime' => true
-                ]"
-            />
+    <div
+        class="grid grid-cols-2 w-full fab-space-x-4"
+        x-cloak
+        x-show="payload.countdown_timer_enabled === true"
+    >
+        <x-fab::forms.date-picker
+            label="Count down until"
+            wire:model="payload.countdown_timer_end_date"
+            wire:key="promobar_countdown_timer_end_date"
+            hint="Required"
+            :options="[
+                'altInput' => true,
+                'altFormat' => 'D, M J, Y - G:i K',
+                'enableTime' => true
+            ]"
+        />
+
+        <x-fab::forms.date-picker
+            label="Show timer after"
+            wire:model="payload.countdown_timer_start_date"
+            wire:key="promobar_countdown_timer_start_date"
+            hint="Optional"
+            :options="[
+                'altInput' => true,
+                'altFormat' => 'D, M J, Y - G:i K',
+                'enableTime' => true
+            ]"
+        />
 
         </div>
     </div>

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -13,16 +13,18 @@
     }
 
     .astrogoat_promobar .countdown-block{
-        background:  {{ $payload['countdown_timer_block_background_color'] ?? '' }};;
+        background:  {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};;
         color: {{ $payload['countdown_timer_block_color'] ?? $payload['text_color'] }};
-
     }
 
+    .astrogoat_promobar .timer-container{
+        padding: 2px 0px;
+    }
 </style>
 
 @isset($payload['content'])
     <div
-        class="astrogoat_promobar mt-4 flex flex-col lg:flex-row lg:mt-0"
+        class="astrogoat_promobar mt-2 flex flex-col lg:flex-row lg:mt-0"
     >
         <span class="mt-1">{!! $payload['content'] ?? '' !!}</span>
 

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -15,7 +15,7 @@
 
 @isset($payload['content'])
     <div
-        class="astrogoat_promobar"
+        class="astrogoat_promobar mt-4 flex flex-col lg:flex-row lg:mt-0"
     >
         <span>{!! $payload['content'] ?? '' !!}</span>
 

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -12,20 +12,43 @@
         margin-left: 10px;
     }
 
-    .astrogoat_promobar .countdown-block{
+    .astrogoat_promobar .countdown-block {
+        padding: 0 0.5rem;
+        border-radius: 0.125rem;
         background: {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};
         color: {{ $payload['text_color'] ?? '#000'  }};
         margin: 0px {{ $payload['countdown_timer_block_padding'] ?? 2 }}px;
     }
 
-    .astrogoat_promobar .timer-container{
+    .astrogoat_promobar .timer-container {
         padding: 2px 0px;
         text-align: center;
         margin-top: 4px;
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .astrogoat_promobar .block-info {
+        text-align: center;
+        font-weight: bold;
+    }
+
+    .astrogoat_promobar .text-xs {
+        font-size: 0.75rem;
+        line-height: 1rem;
+    }
+
+    .astrogoat_promobar .seconds-block,
+    .astrogoat_promobar .minutes-block,
+    .astrogoat_promobar .months-block,
+    .astrogoat_promobar .days-block {
+        font-weight: bold;
+        display: flex;
+        gap: 0.25rem;
     }
 
     @media (min-width: 768px) {
-        .zaius-promobar .container {
+        .astrogoat_promobar .container {
             max-width: 768px;
         }
 
@@ -40,12 +63,12 @@
             max-width: 1280px;
         }
 
-        .astrogoat_promobar .timer-container{
+        .astrogoat_promobar .timer-container {
             padding: 2px 0px;
             margin-top: -4px;
         }
 
-        .astrogoat_promobar .md\:justify-center .timer-container{
+        .astrogoat_promobar .md\:justify-center .timer-container {
             margin-top: 14px;
         }
     }

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -11,13 +11,20 @@
     .astrogoat_promobar_countdown {
         margin-left: 10px;
     }
+
+    .astrogoat_promobar [class*="-block"]{
+        background:  {{ $payload['countdown_timer_block_background_color'] ?? '' }};;
+        color: {{ $payload['countdown_timer_block_color'] ?? '' }};
+
+    }
+
 </style>
 
 @isset($payload['content'])
     <div
         class="astrogoat_promobar"
     >
-        <span>{!! $payload['content'] ?? '' !!}</span>
+        <span class="mt-1">{!! $payload['content'] ?? '' !!}</span>
 
         @if($payload['countdown_timer_enabled'] ?? false)
             <x-promobar::countdown :payload="$payload" class="astrogoat_promobar_countdown" />

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -13,12 +13,41 @@
     }
 
     .astrogoat_promobar .countdown-block{
-        background:  {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};;
-        color: {{ $payload['text_color'] ?? '#FFF'  }};
+        background: {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};
+        color: {{ $payload['text_color'] ?? '#000'  }};
+        margin: 0px {{ $payload['countdown_timer_block_padding'] ?? 2 }}px;
     }
 
     .astrogoat_promobar .timer-container{
         padding: 2px 0px;
+        text-align: center;
+        margin-top: 4px;
+    }
+
+    @media (min-width: 768px) {
+        .zaius-promobar .container {
+            max-width: 768px;
+        }
+
+        .astrogoat_promobar .timer-container{
+            padding: 2px 0px;
+            margin-top: 2px;
+        }
+    }
+
+    @media (min-width: 1280px) {
+        .astrogoat_promobar .container {
+            max-width: 1280px;
+        }
+
+        .astrogoat_promobar .timer-container{
+            padding: 2px 0px;
+            margin-top: -4px;
+        }
+
+        .astrogoat_promobar .md\:justify-center .timer-container{
+            margin-top: 14px;
+        }
     }
 </style>
 

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -14,7 +14,7 @@
 
     .astrogoat_promobar .countdown-block{
         background:  {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};;
-        color: $payload['text_color'] ?? '#FFF'  }};
+        color: {{ $payload['text_color'] ?? '#FFF'  }};
     }
 
     .astrogoat_promobar .timer-container{

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -12,9 +12,9 @@
         margin-left: 10px;
     }
 
-    .astrogoat_promobar [class*="-block"]{
+    .astrogoat_promobar .countdown-block{
         background:  {{ $payload['countdown_timer_block_background_color'] ?? '' }};;
-        color: {{ $payload['countdown_timer_block_color'] ?? '' }};
+        color: {{ $payload['countdown_timer_block_color'] ?? $payload['text_color'] }};
 
     }
 

--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -14,7 +14,7 @@
 
     .astrogoat_promobar .countdown-block{
         background:  {{ $payload['countdown_timer_block_background_color'] ?? '#FFF' }};;
-        color: {{ $payload['countdown_timer_block_color'] ?? $payload['text_color'] }};
+        color: $payload['text_color'] ?? '#FFF'  }};
     }
 
     .astrogoat_promobar .timer-container{

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public $timerType;
-    public $endsAtTime;
+    public string $timerType;
+    public string $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -23,9 +23,9 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
-        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
+        $this->timerType = $this->payload['countdown_timer_type'] ?? "";
 
-        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
+        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public string $timerType;
-    public string $endsAtTime;
+    public $timerType;
+    public $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -23,9 +23,9 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
-        $this->timerType = $this->payload['countdown_timer_type'];
+        $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
 
-        $this->endsAtTime = Carbon::parse($this->payload['countdown_timer_end_date'])->format('H:i:s');
+        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -25,7 +25,7 @@ class Countdown extends Component
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
         $this->timerType = isset($this->payload['countdown_timer_type']) ? $this->payload['countdown_timer_type'] : null;
 
-        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : null;
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -25,7 +25,7 @@ class Countdown extends Component
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
         $this->timerType = $this->payload['countdown_timer_type'] ?? "";
 
-        $this->endsAtTime =  isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
+        $this->endsAtTime = isset($this->endsAt) ? Carbon::parse($this->endsAt)->format('H:i:s') : "";
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,6 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
+    public string $timerType;
+    public string $endsAtTime;
 
     public function __construct(protected array $payload)
     {
@@ -21,6 +23,9 @@ class Countdown extends Component
             ? Carbon::parse($this->payload['countdown_timer_start_date'])
             : null;
         $this->endsAt = Carbon::parse($this->payload['countdown_timer_end_date'] ?? null);
+        $this->timerType = $this->payload['countdown_timer_type'];
+
+        $this->endsAtTime = Carbon::parse($this->payload['countdown_timer_end_date'])->format('H:i:s');
     }
 
     public function days(): string

--- a/src/View/Components/Countdown.php
+++ b/src/View/Components/Countdown.php
@@ -13,8 +13,8 @@ class Countdown extends Component
 
     public Carbon $endsAt;
     public ?Carbon $startsAt;
-    public string $timerType;
-    public string $endsAtTime;
+    public ?string $timerType;
+    public ?string $endsAtTime;
 
     public function __construct(protected array $payload)
     {


### PR DESCRIPTION
**Link to ticket**: https://linear.app/3zbrands/issue/BYTE-158/styling

<details>
<summary>Ticket description</summary>
As a user looking at the promobar when the countdown timer is enabled, I want to see the countdown timer sitting between the copy and the View Offer link (if it exists) so that I know how much time remains until the sale ends.
</details>

