### PR TITLE
BYTE-207: Inline promobar bug

### DIFF
--- a/resources/views/types/inline.blade.php
+++ b/resources/views/types/inline.blade.php
@@ -76,9 +76,9 @@
 
 @isset($payload['content'])
     <div
-        class="astrogoat_promobar mt-2 flex flex-col lg:flex-row lg:mt-0"
+        class="astrogoat_promobar flex flex-col lg:flex-row"
     >
-        <span class="text-xs sm:text-sm">{!! $payload['content'] ?? '' !!}</span>
+        <span>{!! $payload['content'] ?? '' !!}</span>
 
         @if($payload['countdown_timer_enabled'] ?? false)
             <x-promobar::countdown :payload="$payload" class="astrogoat_promobar_countdown" />


### PR DESCRIPTION
**Link to ticket**: https://linear.app/3zbrands/issue/BYTE-207/inline-promobar-bug

<details>
<summary>Ticket description</summary>
Location: URL(s) where the bug is present

Promobar - Inline

Expected Result: What should be happening?

Inline and Zaius promobar types should have the same font size

Actual Result: What is actually happening?

Zaius has the standard promobar font size

Inline promobar type has a much smaller font size now (both desktop and mobile)

Inline promobar has a gap at the top on mobile

Steps to Reproduce: Steps to take to encounter the bug

Set the promobar to Zaius, fill out content → view the site and observe the text size on the promobar

Change the promobar to Inline, fill out content → view the site and observe the text size on the promobar, and notice that it is much smaller than the Zaius promobar type
</details>

